### PR TITLE
Removing -g from zetta install instructions.

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -24,7 +24,7 @@
               <div class="npm pure-u-1 pure-u-md-1-2">
                 <p>Install</p>
                 <div class="install">
-                  <input type="text" value="npm install -g zetta" readonly tabindex=1/>
+                  <input type="text" value="npm install zetta" readonly tabindex=1/>
                 </div>
               </div>
               <div class="build pure-u-1 pure-u-sm-1-2 pure-u-md-1-4">
@@ -257,7 +257,7 @@ zetta()
       <section id="get-started" class="pure-g">
         <h3 class="pure-u-1">Install Zetta</h3>
         <div class="install pure-u-1">
-          <input type="text" value="npm install -g zetta" readonly tabindex=2/>
+          <input type="text" value="npm install zetta" readonly tabindex=2/>
         </div>
       </section>
 


### PR DESCRIPTION
There's no reason to do a global install of Zetta.  It's a module used by server code.
