### PR TITLE
Fixing broken Zetta Browser Link in Step 1 : info text

### DIFF
--- a/projects/_posts/2014-10-13-Hello-World.md
+++ b/projects/_posts/2014-10-13-Hello-World.md
@@ -115,7 +115,7 @@ This project requires a PC with an Internet connection and [Node.js](http://node
    ```
    {:.language-json-noln}
 
-   > **info**{:.icon} As we `use` devices in `server.js` they will appear in the web API. For the following steps we'll access the API via the [Zetta Browser](/guides/2014/10/18/Zetta-Browser.html).
+   > **info**{:.icon} As we `use` devices in `server.js` they will appear in the web API. For the following steps we'll access the API via the [Zetta Browser](/guides/2014/10/07/Zetta-Browser.html).
 
 # Step #2: Blink the LED
 


### PR DESCRIPTION
Broken Link fix for Zetta Browser in Step 1 : info text
![screen shot 2014-11-12 at 2 54 04 pm](https://cloud.githubusercontent.com/assets/401861/5007822/cc7189bc-6a7b-11e4-8cb9-fe448ab297fd.png)
